### PR TITLE
fix(jvb-nlb): TCP target group health-check path /about/health

### DIFF
--- a/modules/jvb-nlb/main.tf
+++ b/modules/jvb-nlb/main.tf
@@ -53,6 +53,8 @@ resource "aws_lb_target_group" "jvb_tcp" {
     enabled             = true
     healthy_threshold   = 2
     interval            = 30
+    # jvb on :8080 serves /about/health; / returns 404 and fails HC.
+    path                = "/about/health"
     port                = "8080"
     protocol            = "HTTP"
     timeout             = 5


### PR DESCRIPTION
Tiny fix surfaced during the #24 rollout.

## Problem

The TCP target group in \`modules/jvb-nlb\` doesn't specify a health check \`path\`, which defaults to \`/\`. jvb's jetty on port 8080 returns 404 at \`/\` and 200 only at \`/about/health\`. Result: TCP target stuck in \`Target.FailedHealthChecks\` permanently.

The UDP target group already has \`path = \"/about/health\"\`. This aligns TCP.

## Evidence

```
$ aws elbv2 describe-target-health --target-group-arn arn:aws:elasticloadbalancing:us-west-2:170473530355:targetgroup/jitsi-video-platform-jvb-tcp-tg/fb112156d7a5e30c \\
    --query 'TargetHealthDescriptions[].{State:TargetHealth.State,Reason:TargetHealth.Reason}'
[{ \"State\": \"unhealthy\", \"Reason\": \"Target.FailedHealthChecks\" }]

$ aws elbv2 describe-target-groups --target-group-arns … --query 'TargetGroups[].HealthCheckPath'
\"/\"   # was the default before this PR
```

Applied as a live hotfix via \`elbv2 modify-target-group --health-check-path /about/health\` in the jitsi account to stop the terraform drift that would have reverted it on next apply. This PR makes the module consistent.

## Test plan

- [ ] Merge → ops repo terraform plan shows no change (live TG already at \`/about/health\`)
- [ ] Or if ops repo applies before merge, the TG flips back to \`/\` and target goes unhealthy — this PR restores and keeps it stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)