### PR TITLE
feat(jibri): ECS-on-EC2 recording module + admin runbook

### DIFF
--- a/docs/JIBRI_RECORDING.md
+++ b/docs/JIBRI_RECORDING.md
@@ -1,0 +1,95 @@
+# Jibri Recording — Admin Runbook
+
+Jibri provides server-side recording for Jitsi Meet. This stack uses one Jibri instance shared across both NE3D and Cloud Del Norte rooms.
+
+---
+
+## Enable / Disable
+
+Jibri is **off by default** (`enable_jibri = false`). Merging the Jibri module into prod.tf changes nothing live until the flag is set.
+
+**Enable:**
+
+```bash
+# in jitsi-video-hosting-ops/terraform/terraform.tfvars
+enable_jibri = true
+
+# then apply (scale-up.pl calls terraform apply)
+cd /path/to/jitsi-video-hosting-ops/terraform/
+terraform apply
+```
+
+**Disable (scale to zero without destroying):**
+
+```bash
+# set desired_count to 0 — or simply power-down the whole stack
+./power-down.pl
+```
+
+---
+
+## How a Moderator Records
+
+1. Join a Jitsi room as moderator (JWT with `recording: true` claim — already set by the token-exchange lambda).
+2. Click the **·⋮** (More actions) menu → **Start recording**.
+3. Jitsi UI shows a red REC indicator while recording is active.
+4. Click **Stop recording** to end. Jibri finalizes the file and uploads it automatically.
+
+No manual intervention needed. The finalize script (`modules/jibri/finalize.sh`) runs inside the Jibri container on completion.
+
+---
+
+## Where Recordings Land
+
+```
+s3://jitsi-video-platform-recordings-<suffix>/recordings/YYYY-MM-DD/<room-name>.<format>
+```
+
+Bucket name is in Terraform output `recordings_bucket_name` and in AWS console.
+
+Lifecycle rule: recordings expire after **90 days** (configurable in `aws_s3_bucket_lifecycle_configuration.recordings`).
+
+---
+
+## Cost Delta
+
+| state                             | additional monthly cost                      |
+| --------------------------------- | -------------------------------------------- |
+| Jibri enabled, stack powered up   | +~$30/mo (1× t3.medium EC2, ~$0.0416/hr)     |
+| Jibri enabled, stack powered down | ~$0 compute; S3 storage only (~$0.023/GB/mo) |
+| Jibri disabled                    | $0                                           |
+
+The recordings S3 bucket persists through power-down and `terraform destroy` (`prevent_destroy = true`).
+
+---
+
+## Why EC2, Not Fargate
+
+Jibri requires:
+
+- **Privileged container** — needed by Chrome's sandbox and device access
+- **`snd-aloop` kernel module** — ALSA loopback for audio capture
+- **`/dev/snd` device** — mounted into the container
+
+Fargate has no host OS control and does not support privileged containers. Jibri runs on a dedicated t3.medium with an ECS-optimized AMI; `snd-aloop` is loaded in EC2 user-data before the ECS agent starts the task.
+
+---
+
+## Troubleshooting
+
+**Record button not visible**
+
+- Confirm `ENABLE_RECORDING=1` is in the prosody container env (already set in prod.tf).
+- Confirm JWT has `recording: true` — check the token-exchange lambda claims.
+
+**Recording starts but Jibri never connects**
+
+- Verify `jibri-service` is RUNNING in ECS console.
+- Check `/ecs/jitsi-app` CloudWatch log stream `jibri/*` for XMPP auth errors.
+- Verify `jibri_xmpp_password` SSM param exists and prosody has `JIBRI_XMPP_USER=jibri` set.
+
+**S3 upload fails after recording**
+
+- Check Jibri container logs for `aws s3 cp` errors.
+- Verify `jibri-ecs-task-role` has `s3:PutObject` on the recordings bucket.
+- Confirm `RECORDINGS_BUCKET` env var matches the actual bucket name.

--- a/modules/jibri/finalize.sh
+++ b/modules/jibri/finalize.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+
+RECORDING_DIR="${1:?Usage: finalize.sh <recording_dir>}"
+
+: "${RECORDINGS_BUCKET:?RECORDINGS_BUCKET env var must be set}"
+
+echo "[finalize] Uploading ${RECORDING_DIR} to s3://${RECORDINGS_BUCKET}/recordings/$(date +%F)/"
+aws s3 cp "${RECORDING_DIR}" "s3://${RECORDINGS_BUCKET}/recordings/$(date +%F)/" --recursive
+echo "[finalize] Upload complete."

--- a/modules/jibri/main.tf
+++ b/modules/jibri/main.tf
@@ -1,0 +1,254 @@
+# ECS-optimized Amazon Linux 2 AMI (latest)
+data "aws_ssm_parameter" "ecs_ami" {
+  name = "/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id"
+}
+
+# ── IAM: EC2 instance role for ECS container agent + S3 recordings ───────────
+
+resource "aws_iam_role" "jibri_instance" {
+  name = "${var.project_name}-jibri-instance-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Action    = "sts:AssumeRole"
+      Principal = { Service = "ec2.amazonaws.com" }
+    }]
+  })
+
+  tags = {
+    Name        = "${var.project_name}-jibri-instance-role"
+    Project     = var.project_name
+    Environment = var.environment
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "jibri_ecs_ec2" {
+  role       = aws_iam_role.jibri_instance.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+}
+
+resource "aws_iam_role_policy" "jibri_s3" {
+  name = "${var.project_name}-jibri-s3"
+  role = aws_iam_role.jibri_instance.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = ["s3:PutObject", "s3:ListBucket"]
+      Resource = [
+        "arn:aws:s3:::${var.recordings_bucket}",
+        "arn:aws:s3:::${var.recordings_bucket}/*"
+      ]
+    }]
+  })
+}
+
+resource "aws_iam_instance_profile" "jibri" {
+  name = "${var.project_name}-jibri-instance-profile"
+  role = aws_iam_role.jibri_instance.name
+}
+
+# ── Launch Template ───────────────────────────────────────────────────────────
+
+resource "aws_launch_template" "jibri" {
+  name_prefix   = "${var.project_name}-jibri-"
+  image_id      = data.aws_ssm_parameter.ecs_ami.value
+  instance_type = var.instance_type
+
+  iam_instance_profile {
+    arn = aws_iam_instance_profile.jibri.arn
+  }
+
+  vpc_security_group_ids = [var.security_group_id]
+
+  # Register with ECS cluster; load snd-aloop for Jibri's virtual audio device.
+  user_data = base64encode(<<-EOF
+    #!/bin/bash
+    echo ECS_CLUSTER=${var.cluster_name} >> /etc/ecs/ecs.config
+    modprobe snd-aloop
+    echo snd-aloop >> /etc/modules-load.d/snd-aloop.conf
+  EOF
+  )
+
+  tag_specifications {
+    resource_type = "instance"
+    tags = {
+      Name        = "${var.project_name}-jibri"
+      Project     = var.project_name
+      Environment = var.environment
+    }
+  }
+}
+
+# ── Auto Scaling Group ────────────────────────────────────────────────────────
+
+resource "aws_autoscaling_group" "jibri" {
+  name                = "${var.project_name}-jibri-asg"
+  min_size            = 0
+  max_size            = var.jibri_count
+  desired_capacity    = var.jibri_count
+  vpc_zone_identifier = var.subnet_ids
+
+  launch_template {
+    id      = aws_launch_template.jibri.id
+    version = "$Latest"
+  }
+
+  # Required so ECS can discover and drain instances.
+  protect_from_scale_in = true
+
+  tag {
+    key                 = "AmazonECSManaged"
+    value               = "true"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "Project"
+    value               = var.project_name
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "Environment"
+    value               = var.environment
+    propagate_at_launch = true
+  }
+}
+
+# ── ECS Capacity Provider ─────────────────────────────────────────────────────
+# NOTE for JIB-2: This module creates the capacity provider resource but does NOT
+# call aws_ecs_cluster_capacity_providers. That resource is cluster-wide and would
+# conflict if prod.tf ever manages it. JIB-2 should add the association in prod.tf:
+#
+#   resource "aws_ecs_cluster_capacity_providers" "main" {
+#     cluster_name       = aws_ecs_cluster.main.name
+#     capacity_providers = [module.jibri[0].capacity_provider_name]
+#   }
+
+resource "aws_ecs_capacity_provider" "jibri" {
+  name = "${var.project_name}-jibri-cp"
+
+  auto_scaling_group_provider {
+    auto_scaling_group_arn         = aws_autoscaling_group.jibri.arn
+    managed_termination_protection = "ENABLED"
+
+    managed_scaling {
+      status          = "ENABLED"
+      target_capacity = 100
+    }
+  }
+
+  tags = {
+    Name        = "${var.project_name}-jibri-cp"
+    Project     = var.project_name
+    Environment = var.environment
+  }
+}
+
+# ── ECS Task Definition ───────────────────────────────────────────────────────
+
+resource "aws_ecs_task_definition" "jibri" {
+  family                   = "${var.project_name}-jibri"
+  requires_compatibilities = ["EC2"]
+  network_mode             = "awsvpc"
+  task_role_arn            = aws_iam_role.jibri_instance.arn
+  execution_role_arn       = var.ecs_task_execution_role_arn
+
+  volume {
+    name      = "recordings"
+    host_path = "/recordings"
+  }
+
+  container_definitions = jsonencode([{
+    name      = "jibri"
+    image     = "jitsi/jibri:stable"
+    essential = true
+
+    # Jibri requires a privileged container for snd-aloop and Chrome sandbox.
+    privileged = true
+
+    linuxParameters = {
+      devices = [{
+        hostPath      = "/dev/snd"
+        containerPath = "/dev/snd"
+        permissions   = ["read", "write"]
+      }]
+    }
+
+    mountPoints = [{
+      sourceVolume  = "recordings"
+      containerPath = "/config/recordings"
+    }]
+
+    environment = [
+      # XMPP_SERVER: resolved via Cloud Map DNS discovery of the jitsi ECS service.
+      { name = "XMPP_SERVER", value = var.prosody_dns },
+      { name = "XMPP_DOMAIN", value = "meet.jitsi" },
+      { name = "XMPP_AUTH_DOMAIN", value = "auth.meet.jitsi" },
+      { name = "XMPP_INTERNAL_MUC_DOMAIN", value = "internal-muc.meet.jitsi" },
+      { name = "XMPP_RECORDER_DOMAIN", value = "recorder.meet.jitsi" },
+      { name = "JIBRI_RECORDER_USER", value = "recorder" },
+      { name = "JIBRI_XMPP_USER", value = "jibri" },
+      { name = "JIBRI_BREWERY_MUC", value = "jibribrewery" },
+      { name = "JIBRI_RECORDING_DIR", value = "/config/recordings" },
+      { name = "JIBRI_FINALIZE_RECORDING_SCRIPT_PATH", value = "/config/finalize.sh" },
+      { name = "RECORDINGS_BUCKET", value = var.recordings_bucket },
+      { name = "DISPLAY", value = ":0" },
+      { name = "TZ", value = "UTC" }
+    ]
+
+    secrets = [
+      { name = "JIBRI_RECORDER_PASSWORD", valueFrom = var.jibri_recorder_password_ssm_arn },
+      { name = "JIBRI_XMPP_PASSWORD", valueFrom = var.jibri_xmpp_password_ssm_arn }
+    ]
+
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        "awslogs-group"         = var.log_group_name
+        "awslogs-region"        = var.region
+        "awslogs-stream-prefix" = "jibri"
+      }
+    }
+  }])
+
+  tags = {
+    Name        = "${var.project_name}-jibri-td"
+    Project     = var.project_name
+    Environment = var.environment
+  }
+}
+
+# ── ECS Service ───────────────────────────────────────────────────────────────
+
+resource "aws_ecs_service" "jibri" {
+  name            = "${var.project_name}-jibri-service"
+  cluster         = var.cluster_id
+  task_definition = aws_ecs_task_definition.jibri.arn
+  desired_count   = var.jibri_count
+
+  capacity_provider_strategy {
+    capacity_provider = aws_ecs_capacity_provider.jibri.name
+    weight            = 1
+  }
+
+  network_configuration {
+    subnets         = var.subnet_ids
+    security_groups = [var.security_group_id]
+  }
+
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+
+  tags = {
+    Name        = "${var.project_name}-jibri-service"
+    Project     = var.project_name
+    Environment = var.environment
+  }
+}

--- a/modules/jibri/outputs.tf
+++ b/modules/jibri/outputs.tf
@@ -1,0 +1,19 @@
+output "asg_name" {
+  description = "Name of the Jibri Auto Scaling Group"
+  value       = aws_autoscaling_group.jibri.name
+}
+
+output "service_name" {
+  description = "Name of the Jibri ECS service"
+  value       = aws_ecs_service.jibri.name
+}
+
+output "capacity_provider_name" {
+  description = "Name of the Jibri ECS capacity provider (wire into aws_ecs_cluster_capacity_providers in JIB-2)"
+  value       = aws_ecs_capacity_provider.jibri.name
+}
+
+output "instance_role_arn" {
+  description = "ARN of the Jibri EC2 instance IAM role"
+  value       = aws_iam_role.jibri_instance.arn
+}

--- a/modules/jibri/variables.tf
+++ b/modules/jibri/variables.tf
@@ -1,0 +1,82 @@
+variable "vpc_id" {
+  description = "VPC ID"
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs for the ASG and ECS service"
+  type        = list(string)
+}
+
+variable "security_group_id" {
+  description = "Security group ID for EC2 instances and ECS tasks"
+  type        = string
+}
+
+variable "cluster_id" {
+  description = "ECS cluster ID"
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "ECS cluster name (written to ecs.config)"
+  type        = string
+}
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "recordings_bucket" {
+  description = "S3 bucket name for recordings"
+  type        = string
+}
+
+variable "log_group_name" {
+  description = "CloudWatch log group name (e.g. /ecs/jitsi-app)"
+  type        = string
+}
+
+variable "jibri_recorder_password_ssm_arn" {
+  description = "SSM parameter ARN for JIBRI_RECORDER_PASSWORD"
+  type        = string
+}
+
+variable "jibri_xmpp_password_ssm_arn" {
+  description = "SSM parameter ARN for JIBRI_XMPP_PASSWORD"
+  type        = string
+}
+
+variable "ecs_task_execution_role_arn" {
+  description = "ECS task execution role ARN (for SSM secret pulls)"
+  type        = string
+}
+
+variable "instance_type" {
+  description = "EC2 instance type for Jibri"
+  type        = string
+  default     = "t3.medium"
+}
+
+variable "jibri_count" {
+  description = "Desired number of Jibri instances"
+  type        = number
+  default     = 1
+}
+
+variable "project_name" {
+  description = "Project name for resource naming and tagging"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (e.g. prod)"
+  type        = string
+  default     = "prod"
+}
+
+variable "prosody_dns" {
+  description = "Cloud Map DNS name for the jitsi service (prosody). Resolved via Route 53 private hosted zone."
+  type        = string
+}

--- a/scripts/power-down.pl
+++ b/scripts/power-down.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 use strict;
 use warnings;
-use lib "../../lib";
+use lib "../lib";
 use JitsiConfig;
 
 # Load configuration

--- a/scripts/scale-up.pl
+++ b/scripts/scale-up.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 use strict;
 use warnings;
-use lib "../../lib";
+use lib "../lib";
 use JitsiConfig;
 
 # Load configuration


### PR DESCRIPTION
Adds the Jibri ECS-on-EC2 recording module (modules/jibri/), admin runbook (docs/JIBRI_RECORDING.md), and use-lib path fix in scale-up.pl + power-down.pl.