### PR TITLE
feat(coturn): self-hosted STUN/TURN/TURNS module for GFW participants

### DIFF
--- a/modules/coturn/entrypoint.sh
+++ b/modules/coturn/entrypoint.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+# entrypoint.sh — write TLS files + turnserver.conf from injected env vars, then exec turnserver.
+#
+# EXTERNAL-IP NOTE: We use the Fargate task metadata endpoint (ECS_CONTAINER_METADATA_URI_V4)
+# to retrieve the task's ENI public IPv4. This is preferred over hardcoding the NLB EIP because
+# this module deliberately skips the NLB (see main.tf: option-b rationale). The public IP changes
+# on redeploy; update your DNS A record (turn.clouddelnorte.org) after each deployment.
+
+set -e
+
+CERT_DIR=/etc/coturn
+mkdir -p "$CERT_DIR"
+
+# Write TLS material injected by ECS secrets
+printf '%s' "$TURN_TLS_CERT_PEM" >"$CERT_DIR/cert.pem"
+printf '%s' "$TURN_TLS_PKEY_PEM" >"$CERT_DIR/pkey.pem"
+chmod 600 "$CERT_DIR/cert.pem" "$CERT_DIR/pkey.pem"
+
+# Resolve ENI public IP via ECS task metadata v4
+EXTERNAL_IP=""
+if [ -n "$ECS_CONTAINER_METADATA_URI_V4" ]; then
+	TASK_META=$(wget -qO- "${ECS_CONTAINER_METADATA_URI_V4}/task" 2>/dev/null || true)
+	# Extract first PublicIpv4Address from the Containers array
+	EXTERNAL_IP=$(printf '%s' "$TASK_META" | grep -o '"PublicIpv4Address":"[^"]*"' | head -1 | cut -d'"' -f4)
+fi
+
+if [ -z "$EXTERNAL_IP" ]; then
+	# Fallback: AWS instance metadata (IMDS v2) — works on Fargate too
+	TOKEN=$(wget -qO- --header "X-aws-ec2-metadata-token-ttl-seconds: 10" \
+		--method PUT http://169.254.169.254/latest/api/token 2>/dev/null || true)
+	EXTERNAL_IP=$(wget -qO- --header "X-aws-ec2-metadata-token: $TOKEN" \
+		http://169.254.169.254/latest/meta-data/public-ipv4 2>/dev/null || true)
+fi
+
+if [ -z "$EXTERNAL_IP" ]; then
+	echo "ERROR: could not determine external IP; coturn will not work correctly" >&2
+	exit 1
+fi
+
+cat >"$CERT_DIR/turnserver.conf" <<EOF
+listening-ip=0.0.0.0
+listening-port=3478
+tls-listening-port=5349
+fingerprint
+use-auth-secret
+static-auth-secret=${TURN_STATIC_AUTH_SECRET}
+realm=${TURN_REALM}
+cert=${CERT_DIR}/cert.pem
+pkey=${CERT_DIR}/pkey.pem
+min-port=${RELAY_MIN_PORT}
+max-port=${RELAY_MAX_PORT}
+external-ip=${EXTERNAL_IP}
+no-tlsv1
+no-tlsv1_1
+no-cli
+no-multicast-peers
+log-file=stdout
+EOF
+
+exec turnserver -c "$CERT_DIR/turnserver.conf"

--- a/modules/coturn/main.tf
+++ b/modules/coturn/main.tf
@@ -1,0 +1,170 @@
+# ─── coturn ECS Fargate module ────────────────────────────────────────────────
+#
+# RELAY PORT RANGE — THE CENTRAL HARD PROBLEM
+# ─────────────────────────────────────────────
+# coturn's TURN relay allocates one UDP port per concurrent session from
+# relay_min_port..relay_max_port. NLB cannot forward an arbitrary port range
+# with a single listener; it requires one listener per port.
+#
+# Three options:
+#   (a) NLB with one listener per relay port — verbose, expensive at scale,
+#       hits NLB listener limits (max 50 per NLB) for any meaningful range.
+#   (b) No NLB — Fargate task with assign_public_ip=true, SG opens the relay
+#       range directly. Task ENI gets a public IP; coturn binds to it.
+#       Tradeoff: public IP changes on redeploy (update DNS A record).
+#   (c) EC2 with static Elastic IP — simplest IP management, loses Fargate.
+#
+# DECISION: option (b). coturn is a single-instance, stateless forwarder.
+# No NLB is needed. The SG opens 3478/udp+tcp, 5349/tcp, and the relay UDP
+# range. On redeploy, update turn.clouddelnorte.org → new ENI public IP.
+# ──────────────────────────────────────────────────────────────────────────────
+
+locals {
+  name_prefix = "${var.project_name}-coturn-${var.environment}"
+}
+
+# ── Security Group ────────────────────────────────────────────────────────────
+resource "aws_security_group" "coturn" {
+  name        = "${local.name_prefix}-sg"
+  description = "coturn STUN/TURN/TURNS — no NLB, direct public ENI"
+  vpc_id      = var.vpc_id
+
+  # STUN/TURN plaintext
+  ingress {
+    from_port   = 3478
+    to_port     = 3478
+    protocol    = "udp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  ingress {
+    from_port   = 3478
+    to_port     = 3478
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # TURNS over TLS (5349/tcp survives DPI / GFW HTTPS inspection)
+  ingress {
+    from_port   = 5349
+    to_port     = 5349
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Relay UDP range — keep small (default 41 ports ≈ 10 concurrent sessions)
+  ingress {
+    from_port   = var.relay_min_port
+    to_port     = var.relay_max_port
+    protocol    = "udp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Name = "${local.name_prefix}-sg" }
+}
+
+# ── IAM inline policy — allow execution role to read TLS cert + auth secret ──
+resource "aws_iam_role_policy" "coturn_secrets" {
+  name = "${local.name_prefix}-secrets"
+  role = split("/", var.ecs_task_execution_role_arn)[1]
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["secretsmanager:GetSecretValue"]
+        Resource = var.turn_cert_secret_arn
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["ssm:GetParameter", "ssm:GetParameters"]
+        Resource = var.turn_static_auth_secret_ssm_arn
+      }
+    ]
+  })
+}
+
+# ── Task Definition ───────────────────────────────────────────────────────────
+resource "aws_ecs_task_definition" "coturn" {
+  family                   = "${local.name_prefix}-td"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = tostring(var.task_cpu)
+  memory                   = tostring(var.task_memory)
+  execution_role_arn       = var.ecs_task_execution_role_arn
+
+  container_definitions = jsonencode([{
+    name      = "coturn"
+    image     = var.coturn_image
+    essential = true
+
+    # entrypoint.sh is embedded via a base64-encoded command override so we
+    # don't need a custom image build. The shell script is written inline.
+    # NOTE: if you prefer a custom image, bake entrypoint.sh into it and
+    # remove the command override below.
+    entryPoint = ["/bin/sh", "-c"]
+    command    = [file("${path.module}/entrypoint.sh")]
+
+    portMappings = [
+      { containerPort = 3478, protocol = "udp" },
+      { containerPort = 3478, protocol = "tcp" },
+      { containerPort = 5349, protocol = "tcp" }
+    ]
+
+    environment = [
+      { name = "TURN_REALM", value = var.turn_realm },
+      { name = "RELAY_MIN_PORT", value = tostring(var.relay_min_port) },
+      { name = "RELAY_MAX_PORT", value = tostring(var.relay_max_port) }
+    ]
+
+    # ECS injects Secrets Manager JSON key selectors with :key:: suffix syntax.
+    # Secret must be a JSON object: {"cert": "<PEM>", "pkey": "<PEM>"}
+    secrets = [
+      { name = "TURN_TLS_CERT_PEM", valueFrom = "${var.turn_cert_secret_arn}:cert::" },
+      { name = "TURN_TLS_PKEY_PEM", valueFrom = "${var.turn_cert_secret_arn}:pkey::" },
+      { name = "TURN_STATIC_AUTH_SECRET", valueFrom = var.turn_static_auth_secret_ssm_arn }
+    ]
+
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        "awslogs-group"         = var.log_group_name
+        "awslogs-region"        = var.region
+        "awslogs-stream-prefix" = "coturn"
+      }
+    }
+  }])
+
+  tags = { Name = "${local.name_prefix}-td" }
+
+  depends_on = [aws_iam_role_policy.coturn_secrets]
+}
+
+# ── ECS Service (no NLB — direct public ENI, option b) ───────────────────────
+resource "aws_ecs_service" "coturn" {
+  name            = "${local.name_prefix}-svc"
+  cluster         = var.cluster_id
+  task_definition = aws_ecs_task_definition.coturn.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = var.subnet_ids
+    security_groups  = [aws_security_group.coturn.id]
+    assign_public_ip = true # ENI gets a public IP; coturn binds to it via external-ip discovery
+  }
+
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+
+  tags = { Name = "${local.name_prefix}-svc" }
+}

--- a/modules/coturn/outputs.tf
+++ b/modules/coturn/outputs.tf
@@ -1,0 +1,14 @@
+output "service_name" {
+  description = "ECS service name"
+  value       = aws_ecs_service.coturn.name
+}
+
+output "security_group_id" {
+  description = "ID of the coturn security group (opens 3478 udp/tcp, 5349 tcp, relay UDP range)"
+  value       = aws_security_group.coturn.id
+}
+
+output "public_endpoint_note" {
+  description = "Operational note: coturn has no NLB. The task ENI public IP changes on each redeploy. After apply, retrieve the running task's public IP and update your DNS A record for var.turn_realm."
+  value       = "No static endpoint — update DNS A record for ${var.turn_realm} after each redeploy. Run: aws ecs describe-tasks --cluster <cluster> --tasks <task-arn> | jq '.tasks[].attachments[].details[] | select(.name==\"networkInterfaceId\")' then aws ec2 describe-network-interfaces --network-interface-ids <eni-id> | jq '.NetworkInterfaces[].Association.PublicIp'"
+}

--- a/modules/coturn/variables.tf
+++ b/modules/coturn/variables.tf
@@ -1,0 +1,90 @@
+variable "vpc_id" {
+  description = "VPC ID"
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "List of public subnet IDs (assign_public_ip=true, so public subnets required)"
+  type        = list(string)
+}
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "cluster_id" {
+  description = "ECS cluster ID"
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "ECS cluster name"
+  type        = string
+}
+
+variable "log_group_name" {
+  description = "CloudWatch log group name"
+  type        = string
+}
+
+variable "ecs_task_execution_role_arn" {
+  description = "ARN of the ECS task execution IAM role"
+  type        = string
+}
+
+variable "turn_realm" {
+  description = "TURN realm (e.g. turn.clouddelnorte.org)"
+  type        = string
+}
+
+variable "turn_cert_secret_arn" {
+  description = "Secrets Manager ARN for TLS cert+key JSON blob with keys 'cert' and 'pkey'"
+  type        = string
+}
+
+variable "turn_static_auth_secret_ssm_arn" {
+  description = "SSM Parameter ARN (SecureString) holding the static-auth-secret for time-limited TURN credentials"
+  type        = string
+}
+
+variable "coturn_image" {
+  description = "coturn Docker image"
+  type        = string
+  default     = "coturn/coturn:latest"
+}
+
+variable "relay_min_port" {
+  description = "Minimum UDP relay port (keep range small — each port needs a SG rule)"
+  type        = number
+  default     = 49160
+}
+
+variable "relay_max_port" {
+  description = "Maximum UDP relay port (default 49200 = 41 ports; expand if concurrent sessions > ~10)"
+  type        = number
+  default     = 49200
+}
+
+variable "task_cpu" {
+  description = "Fargate task CPU units"
+  type        = number
+  default     = 256
+}
+
+variable "task_memory" {
+  description = "Fargate task memory (MiB)"
+  type        = number
+  default     = 512
+}
+
+variable "project_name" {
+  description = "Project name for resource tagging/naming"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment (e.g. prod, staging)"
+  type        = string
+  default     = "prod"
+}


### PR DESCRIPTION
Gated/unwired module — not yet wired into any live stack. Provides a TURNS-over-5349 relay to replace blocked Google STUN for participants behind the GFW.

Files: modules/coturn/{main.tf, variables.tf, outputs.tf, entrypoint.sh}